### PR TITLE
Another description for `NormalMotionTerm`

### DIFF
--- a/src/levelsetterms.jl
+++ b/src/levelsetterms.jl
@@ -147,7 +147,7 @@ end
     struct NormalMotionTerm{V,M} <: LevelSetTerm
 
 Level-set advection term representing  `v |∇ϕ|`. This `LevelSetTerm` should be
-used for internally generated velocity fields; for externally generated
+used for normal velocity fields only; for arbitrary oriented
 velocities you may use `AdvectionTerm` instead.
 """
 @Base.kwdef struct NormalMotionTerm{V,M} <: LevelSetTerm


### PR DESCRIPTION
The `NormalMotionTerm` is a special case of the `AdvectionTerm`, when the external velocity  is always  normal to the level sets.